### PR TITLE
Support latest stable version. Fixes raiguard/ChangeInserterDropLane#1

### DIFF
--- a/info.json
+++ b/info.json
@@ -7,7 +7,7 @@
   "contact": "https://github.com/raiguard/ChangeInserterDropLane",
   "homepage": "https://github.com/raiguard/ChangeInserterDropLane",
   "factorio_version": "1.1",
-  "dependencies": [ "base >= 1.1.77", "flib >= 0.12.0", "simhelper" ],
+  "dependencies": [ "base >= 1.1.76", "flib >= 0.12.0", "simhelper" ],
   "package": {
     "ignore": [ ".github", ".kakrc", ".vscode", ".xcf", "stylua.toml" ]
   }


### PR DESCRIPTION
Support latest stable version (1.1.76) of factorio.